### PR TITLE
update html-minifier

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,8 +22,8 @@
   ],
   "main": "./index.js",
   "dependencies": {
-    "lodash": "~2.2.1",
-    "html-minifier": "~0.5.4"
+    "html-minifier": "~0.6.9",
+    "lodash": "~2.2.1"
   },
   "devDependencies": {
     "assemble": "~0.4.24",


### PR DESCRIPTION
Hi.
I want to update html-minifier, because the option `minifyJS` seem to not available on 
the current version used in handlebars-helper-minify.
